### PR TITLE
Fix: suppress warn ios onclick animated

### DIFF
--- a/index.js
+++ b/index.js
@@ -170,7 +170,8 @@ class TabBar extends Component {
       }),
       Animated.timing(this.animatedImageValues[index], {
         toValue: 1,
-        duration: 800
+        duration: 800,
+        useNativeDriver: true
       })
     ]).start();
   };
@@ -197,7 +198,8 @@ class TabBar extends Component {
       Animated.timing(this.animatedImageValues[index], {
         toValue: 0,
         duration: 400,
-        delay: 350
+        delay: 350,
+        useNativeDriver: false
       })
     ]).start();
   };


### PR DESCRIPTION
Animated: 'useNativeDriver' was not specified. this is a required option and must be explicitly set to 'true' of 'false'

![image](https://user-images.githubusercontent.com/13028902/131379120-1a62d216-d741-4073-8e42-84be0d98b20d.png)
